### PR TITLE
Rotated 90° chest loot stuck in wall fix

### DIFF
--- a/Project Reboot 3.0/Actor.cpp
+++ b/Project Reboot 3.0/Actor.cpp
@@ -114,6 +114,15 @@ FVector AActor::GetActorRightVector()
 	return ret;
 }
 
+FVector AActor::GetActorUpVector()
+{
+	static auto GetActorUpVectorFn = FindObject<UFunction>("/Script/Engine.Actor.GetActorUpVector");
+	FVector ret;
+	this->ProcessEvent(GetActorUpVectorFn, &ret);
+
+	return ret;
+}
+
 FRotator AActor::GetActorRotation()
 {
 	static auto K2_GetActorRotationFn = FindObject<UFunction>(L"/Script/Engine.Actor.K2_GetActorRotation");

--- a/Project Reboot 3.0/Actor.h
+++ b/Project Reboot 3.0/Actor.h
@@ -28,6 +28,7 @@ public:
 	struct FVector GetActorScale3D();
 	struct FVector GetActorLocation();
 	struct FVector GetActorRightVector();
+	struct FVector GetActorUpVector();
 	void K2_DestroyActor();
 	class UActorComponent* GetComponentByClass(class UClass* ComponentClass);
 	float GetDistanceTo(AActor* OtherActor);

--- a/Project Reboot 3.0/BuildingContainer.cpp
+++ b/Project Reboot 3.0/BuildingContainer.cpp
@@ -7,7 +7,7 @@
 bool ABuildingContainer::SpawnLoot(AFortPawn* Pawn)
 {
 	auto GameMode = Cast<AFortGameModeAthena>(GetWorld()->GetGameMode());
-	FVector LocationToSpawnLoot = this->GetActorLocation() + this->GetActorRightVector() * 70.f + FVector{ 0, 0, 50 };
+	FVector LocationToSpawnLoot = this->GetActorLocation() + this->GetActorRightVector() * 70.f + this->GetActorUpVector() * 50.f;
 
 	static auto SearchLootTierGroupOffset = this->GetOffset("SearchLootTierGroup");
 	auto RedirectedLootTier = GameMode->RedirectLootTier(this->Get<FName>(SearchLootTierGroupOffset));


### PR DESCRIPTION
### The container loot spawn locations height increase by 50 will now base on the container's pitch, just like the X and Y coordinates.

## **Before:**
![gifbefore](https://github.com/Milxnor/Project-Reboot-3.0/assets/67335438/33b3025c-de88-4d6a-a7e9-b1a000992e9a)

## **After:**
![gifafter](https://github.com/Milxnor/Project-Reboot-3.0/assets/67335438/344d5713-bf59-4582-9332-f6e27592a768)
