### PR TITLE
crashfix: prevent division by zero when spawning too many bots

### DIFF
--- a/Project Reboot 3.0/botnames.h
+++ b/Project Reboot 3.0/botnames.h
@@ -69,4 +69,6 @@ static inline void InitBotNames()
     PlayerBotNames.push_back(L"AllyJax");
     PlayerBotNames.push_back(L"secret_pommes");
     PlayerBotNames.push_back(L"Twin1");
+
+    std::shuffle(PlayerBotNames.begin(), PlayerBotNames.end(), std::default_random_engine((unsigned int)time(0)));
 }

--- a/Project Reboot 3.0/bots.h
+++ b/Project Reboot 3.0/bots.h
@@ -232,21 +232,15 @@ public:
 		}
 		else
 		{
-			if (Fortnite_Version < 11)
+			if (Fortnite_Version < 11 || PlayerBotNames.empty())
 			{
 				BotNumWStr = std::to_wstring(CurrentBotNum++ + 200);
 				NewName = (std::format(L"Anonymous[{}]", BotNumWStr)).c_str();
 			}
 			else
 			{
-				if (!PlayerBotNames.empty())
-				{
-					// std::shuffle(PlayerBotNames.begin(), PlayerBotNames.end(), std::default_random_engine((unsigned int)time(0)));
-
-					int RandomIndex = std::rand() % (PlayerBotNames.size() - 1);
-					NewName = PlayerBotNames[RandomIndex];
-					PlayerBotNames.erase(PlayerBotNames.begin() + RandomIndex);
-				}
+				NewName = PlayerBotNames.back();
+				PlayerBotNames.pop_back();
 			}
 		}
 


### PR DESCRIPTION
ExceptionCode: c0000094 (Integer divide-by-zero)
Faulting source line : https://github.com/Milxnor/Project-Reboot-3.0/blob/76f540b426744c18030b4546acf7a21a52f3f221/Project%20Reboot%203.0/bots.h#L246

This PR should fix it,  I made it fall back to anonymous usernames once the player names array is empty
![image](https://github.com/user-attachments/assets/f38f99cf-072d-46af-9688-1051a7ee18af)
