### PR TITLE
Fix v1.8.1 not being recognised correctly

### DIFF
--- a/Project Reboot 3.0/addresses.cpp
+++ b/Project Reboot 3.0/addresses.cpp
@@ -96,6 +96,8 @@ void Addresses::SetupVersion()
 		Fortnite_Version = 1.72;
 	if (Fortnite_CL == 3724489)
 		Fortnite_Version = 1.8;
+	if (Fortnite_CL == 3729133)
+		Fortnite_Version = 1.8; // 1.8.1
 	if (Fortnite_CL == 3741772)
 		Fortnite_Version = 1.8; // 1.8.2
 	if (Fortnite_CL == 3757339)


### PR DESCRIPTION
Very simple addition, very simple PR. Fixes 1.8.1 locking up on the loading screen.
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/405ae25d-fec3-49cd-b916-0124ce658e47" />