### PR TITLE
1.9 No reservation in game

### DIFF
--- a/Project Reboot 3.0/addresses.cpp
+++ b/Project Reboot 3.0/addresses.cpp
@@ -586,7 +586,7 @@ std::vector<uint64> Addresses::GetFunctionsToReturnTrue()
 {
 	std::vector<uint64> toReturnTrue;
 
-	if (Fortnite_Version == 1.10 || Fortnite_Version == 1.11 || Fortnite_Version >= 2.2 && Fortnite_Version <= 2.4)
+	if (Fortnite_Version == 1.9 || Fortnite_Version == 1.10 || Fortnite_Version == 1.11 || Fortnite_Version >= 2.2 && Fortnite_Version <= 2.4)
 	{
 		toReturnTrue.push_back(Memcury::Scanner::FindPattern("48 89 5C 24 ? 48 89 6C 24 ? 57 41 56 41 57 48 81 EC ? ? ? ? 48 8B 01 49 8B E9 45 0F B6 F8").Get()); // No Reserve
 	}


### PR DESCRIPTION
Attempting to join reboot game server on 1.9 causes "No reservation in game" error.
Easy fix: pattern is used for 1.10-2.4 on reboot 3.0. The same exact pattern was used in reboot 2.0 for all UE 4.16 versions. Simply include 1.9 in the condition for the pattern. 1.7.2-1.8.2 don't need this, as they already work.